### PR TITLE
Hard-cache for a day to give us space

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -169,3 +169,19 @@ def handle_error(error):
         jsonify({"message": "Invalid payload", "errors": str(messages)}),
         422,
     )
+
+
+@app.after_request
+def cache_for_a_day(response):
+    """
+    The security API is in trouble, returning 504 and 503 errors.
+    The application is clearly not performing sufficiently to handle the load,
+    but we need space to find out why.
+    So as a temporary emergency solution let's radically extend the cache time.
+    @TODO: REMOVE THIS AS SOON AS WE'RE NO LONGER FIREFIGHTING.
+    """
+
+    # Hard-cache all responses for a day
+    response.cache_control.max_age = "86400"
+
+    return response


### PR DESCRIPTION
If the application is actively erroring, then we need to follow the quickest path to identifying and applying fixes that are likely to stop the errors.

Are there immediate things we can do that don’t even require us to try to understand what’s going on?

If we start at the very top of the stack to see if we can find ways to lessen the load on the lower parts of the stack. The very top of the stack is the Nginx proxy cache.

At the moment, cache instructions are:

`cache-control: max-age=60, stale-while-revalidate=86400, stale-if-error=300`

This means that, after a cache node has stored a given path's response (for a given "accept-encoding" request) for 60 seconds, then, for the first request it recieves on that path+encoding it will then poll the application to check if the content has changed, and when it receives a successful response it will cache it for 60 seconds again.

This means that, per specific cache node, path, and content encoding, and if the application is healthy, the application shouldn't recieve more than one request per minute. (Also, the "revalidate" config *might* protect the application further, depending on how it works, which I'm not quite sure about).

This setup should significantly protect the application from high load, as long as that load involves at least dozens of requests on the same path within a single minute.

I say "at least dozens on the same path" because:

1. We need probably 3-5 similar requests to prime all 3 cache nodes (as there's a degree of randomness); and
2. Nginx is configured to "vary" the cache by the "accept-encoding" header, as in it will keep a separate cache for each version of that header that it encounters in requests from clients. And it's not in any way smart, it's literal string comparison, so `gzip,br` will use a different cache from `br,gzip` (although I think it might at least remove spaces before making the comparison).

    This variance is less of a problem for browser-facing endpoints, because something like 98% of people use browsers that send an identical accept-encoding header. I can't find a solid source for this, but I did and wrote up a lengthy investigation into this while at Canonical, which I now can't find. (@mtruj013 maybe you could search in Canonical's docs and see if you can find it?). Even for HTML endpoints it's likely that web crawlers with different `accept-encoding` provide enough varied traffic to keep the application busy, even if the app is largely protected from browser traffic itself.

    But for APIs, it's fairly likely that the variance in `accept-encoding` headers is far greater, as the diversity of clients who may call the API is also far greater. So the number split caches, even under the same path and cache node, is also likely to be far greater. I haven't done this analysis, it would be interesting to do.

If we, as an emergency state, change this to hard-cache for a day then the application should be protected from all requests at the same path and content-encoding, from the same cache node. This probably means that in a day, we should probably only receive, let’s say, 10-15 requests total at any given path. It’s hard to say how many path variants there are, as obviously the query parameters can vary and be shaped in various ways.

But still, it’s reasonable to assume that this should *massively* reduce the load on the application, as long as the cache is doing its job.

## QA steps

Run the application locally, then hit the "cve.json" endpoint with `curl -I`, and check you see `cache-control: max-age=86400` (instead of `=60`)

## Checking

Once this is released, we can check if it's working as expected by curling the API:

```
$ curl -I https://ubuntu.com/security/cves.json
HTTP/2 200
...
cache-control: max-age=86400, stale-while-revalidate=86400, stale-if-error=300
...
x-cache-status: HIT from content-cache-il3/0
```

Run it a few times and check:
-  you see `cache-control: max-age=86400` (rather than `max-age=60`
- That `x-cache-status` is consistently returning `HIT`